### PR TITLE
Enable News menu, since that will be useful going forward

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -67,8 +67,8 @@ WAFER_MENUS += (
          {"name": "speakers", "label": _("Speakers"),
           "url": reverse_lazy("wafer_talks_speakers")},
         ]},
-    #{"menu": "events", "label": _("News"),
-    # "items": []},
+    {"menu": "news", "label": _("News"),
+     "items": []},
     {"menu": "previous-pycons", "label": _("Past PyConZAs"),
      "items": [
          {"name": "pyconza2012", "label": _("PyConZA 2012"),


### PR DESCRIPTION
We're now at the point were News items will be appearing, so let's re-enable the menu.

This year, we created that container page as 'news', not 'events', probably from manually copying last years' menu structure for pages not in the selected fixture list.
